### PR TITLE
Added /usr/sbin to PATH

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+udoo-web-conf (0.3.1) trusty; urgency=medium
+
+  * Minor changes from github
+
+ -- Christian Ehlers <webmaster@tiny-dev.com>  Mon, 28 Mar 2015 13:00:00 +0100
+
 udoo-web-conf (0.3.0) trusty; urgency=medium
 
   * New UI

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Vcs-Browser: https://github.com/UDOOboard/udoo-web-conf/
 
 Package: udoo-web-conf
 Architecture: all
-Depends: ${misc:Depends}, udoo-web-docs, nodejs (>=5.7),
+Depends: ${misc:Depends}, udoo-web-docs, nodejs (>=0.12),
  udoo-web-conf-modules (= ${source:Version}), network-manager, dtweb
 Description: UDOO Neo Web Configurator
  This tool is designed to allow easy configuration and act as an handy web-based
@@ -17,7 +17,7 @@ Description: UDOO Neo Web Configurator
 
 Package: udoo-web-conf-modules
 Architecture: armhf
-Depends: ${misc:Depends}, nodejs (>=5.7)
+Depends: ${misc:Depends}, nodejs (>=0.12)
 Description: UDOO Neo Web Configurator - Node modules
  This tool is designed to allow easy configuration and act as an handy web-based
  control panel for UDOO NEO.

--- a/debian/udoo-web-conf.upstart
+++ b/debian/udoo-web-conf.upstart
@@ -7,7 +7,7 @@ description "UDOO Neo Web Configurator"
 author "UDOO Team <social@udoo.org>"
 
 env USER=root
-env PATH=/sbin:/bin:/usr/bin
+env PATH=/sbin:/bin:/usr/bin:/usr/sbin
 
 start on local-filesystems
 stop on [06]


### PR DESCRIPTION
The web interface is trying to run some commands in /usr/sbin but they can't be found. Adding /usr/sbin to the PATH variable in the init script fixes the issue.
